### PR TITLE
Conditionreports

### DIFF
--- a/Fino.ino
+++ b/Fino.ino
@@ -1,6 +1,6 @@
 #define DEBUGNO
 // the digits mean Mmmmrrr (M=Major,m=minor,r=revision)
-#define SKETCH_VERSION 2001001
+#define SKETCH_VERSION 2002000
 
 #include "src/Joystick.h"
 #include "config.h"

--- a/Fino.ino
+++ b/Fino.ino
@@ -39,7 +39,7 @@ int32_t forces[2] = {0, 0};
 Joystick_ Joystick(
     JOYSTICK_DEFAULT_REPORT_ID, JOYSTICK_TYPE_JOYSTICK,
     19, 2, // Button Count, Hat Switch Count
-    true, true, true, // X, Y, Z
+    true, true, false, // X, Y, Z
     false, false, false, // Rx, Ry, Rz
     true, true); // rudder, throttle
 

--- a/Fino.ino
+++ b/Fino.ino
@@ -39,7 +39,7 @@ int32_t forces[2] = {0, 0};
 Joystick_ Joystick(
     JOYSTICK_DEFAULT_REPORT_ID, JOYSTICK_TYPE_JOYSTICK,
     19, 2, // Button Count, Hat Switch Count
-    true, true, false, // X, Y, Z
+    true, true, true, // X, Y, Z
     false, false, false, // Rx, Ry, Rz
     true, true); // rudder, throttle
 

--- a/src/DynamicHID/PIDReportHandler.cpp
+++ b/src/DynamicHID/PIDReportHandler.cpp
@@ -229,41 +229,12 @@ void PIDReportHandler::SetCondition(USB_FFBReport_SetCondition_Output_Data_t* da
             effect->conditionReportsCount = axis + 1;
         }
 
-        // if we only find one condition report, calculate one per axis based
-        // on the condition values and the effect direction
-        // if we end up receiving more reports they
-        // would just overwrite this data
-        if (effect->conditionReportsCount == 1)
-        {
-            float cos_x = cos(effect->direction[0]);
-            float sin_x = sin(effect->direction[0]);
-            float max_cos_sin = abs(cos_x) > abs(sin_x) ? abs(cos_x) : abs(sin_x);
-            for (int i=0; i<FFB_AXIS_COUNT; ++i)
-            {
-                float angle = (i < 2 ? effect->direction[0] : effect->direction[1]) * 360.0 / 255.0 * DEG_TO_RAD;
-                float angle_ratio;
-                if (axis == 0)
-                {
-                    // angle=0 points "up"
-                    angle_ratio = -sin_x / max_cos_sin;
-                } else {
-                    angle_ratio = cos(angle) / max_cos_sin;
-                }
-                effect->conditions[i].cpOffset = data->cpOffset * angle_ratio;
-                effect->conditions[i].positiveCoefficient = data->positiveCoefficient * angle_ratio;
-                effect->conditions[i].negativeCoefficient = data->negativeCoefficient * angle_ratio;
-                effect->conditions[i].positiveSaturation = data->positiveSaturation * angle_ratio;
-                effect->conditions[i].negativeSaturation = data->negativeSaturation * angle_ratio;
-                effect->conditions[i].deadBand = data->deadBand * angle_ratio;
-            }
-        } else {
-            effect->conditions[axis].cpOffset = data->cpOffset;
-            effect->conditions[axis].positiveCoefficient = data->positiveCoefficient;
-            effect->conditions[axis].negativeCoefficient = data->negativeCoefficient;
-            effect->conditions[axis].positiveSaturation = data->positiveSaturation;
-            effect->conditions[axis].negativeSaturation = data->negativeSaturation;
-            effect->conditions[axis].deadBand = data->deadBand;
-        }
+        effect->conditions[axis].cpOffset = data->cpOffset;
+        effect->conditions[axis].positiveCoefficient = data->positiveCoefficient;
+        effect->conditions[axis].negativeCoefficient = data->negativeCoefficient;
+        effect->conditions[axis].positiveSaturation = data->positiveSaturation;
+        effect->conditions[axis].negativeSaturation = data->negativeSaturation;
+        effect->conditions[axis].deadBand = data->deadBand;
 }
 
 void PIDReportHandler::SetPeriodic(USB_FFBReport_SetPeriodic_Output_Data_t* data, volatile TEffectState* effect)
@@ -311,13 +282,13 @@ void PIDReportHandler::UppackUsbData(uint8_t* data, uint16_t len)
 {
 	//Serial.print("len:");
 	//Serial.println(len);
-    for (uint16_t i=0; i<len; ++i) {
-      if (data[i] < 0xA0) {
-        Serial.print(" ");
-      }
-      Serial.print(data[i], HEX);
-    }
-    Serial.println("");
+    //for (uint16_t i=0; i<len; ++i) {
+    //  if (data[i] < 0xA0) {
+    //    Serial.print(" ");
+    //  }
+    //  Serial.print(data[i], HEX);
+    //}
+    //Serial.println("");
 	uint8_t effectId = data[1]; // effectBlockIndex is always the second byte.
 	switch (data[0])    // reportID
 	{

--- a/src/DynamicHID/PIDReportHandler.cpp
+++ b/src/DynamicHID/PIDReportHandler.cpp
@@ -275,6 +275,13 @@ void PIDReportHandler::UppackUsbData(uint8_t* data, uint16_t len)
 {
 	//Serial.print("len:");
 	//Serial.println(len);
+    for (uint16_t i=0; i<len; ++i) {
+      if (data[i] < 0xA0) {
+        Serial.print(" ");
+      }
+      Serial.print(data[i], HEX);
+    }
+    Serial.println("");
 	uint8_t effectId = data[1]; // effectBlockIndex is always the second byte.
 	switch (data[0])    // reportID
 	{

--- a/src/DynamicHID/PIDReportType.h
+++ b/src/DynamicHID/PIDReportType.h
@@ -28,7 +28,7 @@
 #define _PIDREPORTTYPE_H
 
 #define MAX_EFFECTS 14
-#define FFB_AXIS_COUNT 2
+#define FFB_AXIS_COUNT 3
 #define SIZE_EFFECT sizeof(TEffectState)
 #define MEMORY_SIZE (uint16_t)(MAX_EFFECTS*SIZE_EFFECT)
 #define TO_LT_END_16(x) ((x<<8)&0xFF00)|((x>>8)&0x00FF)

--- a/src/DynamicHID/PIDReportType.h
+++ b/src/DynamicHID/PIDReportType.h
@@ -28,7 +28,7 @@
 #define _PIDREPORTTYPE_H
 
 #define MAX_EFFECTS 14
-#define FFB_AXIS_COUNT 3
+#define FFB_AXIS_COUNT 2
 #define SIZE_EFFECT sizeof(TEffectState)
 #define MEMORY_SIZE (uint16_t)(MAX_EFFECTS*SIZE_EFFECT)
 #define TO_LT_END_16(x) ((x<<8)&0xFF00)|((x>>8)&0x00FF)
@@ -205,7 +205,8 @@ typedef struct// FFB: PID Pool Feature Report
 
 #define X_AXIS_ENABLE				0x01
 #define Y_AXIS_ENABLE				0x02
-#define DIRECTION_ENABLE			0x04
+#define Z_AXIS_ENABLE				0x04
+#define DIRECTION_ENABLE			0x01 << FFB_AXIS_COUNT
 //these were needed for testing
 #define INERTIA_FORCE 				0xFF
 #define FRICTION_FORCE				0xFF

--- a/src/DynamicHID/PIDReportType.h
+++ b/src/DynamicHID/PIDReportType.h
@@ -59,8 +59,7 @@ typedef struct //FFB: Set Effect Output Report
 	uint8_t	gain;	// 0..255	 (physical 0..10000)
 	uint8_t	triggerButton;	// button ID (0..8)
 	uint8_t	enableAxis; // bits: 0=X, 1=Y, 2=DirectionEnable
-	uint8_t	directionX;	// angle (0=0 .. 255=360deg)
-	uint8_t	directionY;	// angle (0=0 .. 255=360deg)
+	uint8_t	direction[FFB_AXIS_COUNT];	// angle (0=0 .. 255=360deg)
 } USB_FFBReport_SetEffect_Output_Data_t;
 
 typedef struct//FFB: Set Envelope Output Report
@@ -230,8 +229,7 @@ typedef struct {
 	int16_t attackLevel, fadeLevel;
 	int16_t magnitude;
 	uint8_t enableAxis; // bits: 0=X, 1=Y, 2=DirectionEnable
-	uint8_t directionX; // angle (0=0 .. 255=360deg)
-	uint8_t directionY; // angle (0=0 .. 255=360deg)
+	uint8_t direction[FFB_AXIS_COUNT]; // angle (0=0 .. 255=360deg)
 
 	TEffectCondition conditions[FFB_AXIS_COUNT];
 
@@ -242,5 +240,6 @@ typedef struct {
 	uint16_t duration, fadeTime, attackTime, elapsedTime, totalDuration, startDelay;
 	uint64_t startTime;
 	uint8_t loopCount;
+	uint8_t conditionReportsCount;
 } TEffectState;
 #endif

--- a/src/FFBDescriptor.h
+++ b/src/FFBDescriptor.h
@@ -113,23 +113,25 @@ static const uint8_t pidReportDescriptor[] PROGMEM= {
 	  0x05, 0x01,           //        Usage Page (Generic Desktop)
 	  0x09, 0x30,           //        Usage (X)//
 	  0x09, 0x31,           //        Usage (Y)//
+	  0x09, 0x32,           //        Usage (Z)//
 	  0x15, 0x00,           //        Logical Minimum (0)
 	  0x25, 0x01,           //        Logical Maximum (1)
 	  0x75, 0x01,           //        Report Size (1)
-	  0x95, 0x02,           //        Report Count (2)
+	  0x95, 0x03,           //        Report Count (3)
 	  0x91, 0x02,           //        Output (Data,Var,Abs)
 	0xC0,                 //      End Collection Datalink (Logical)
 
 	0x05, 0x0F,           //    Usage Page (Physical Interface)
 	0x09, 0x56,           //      Usage (Direction Enable)
 	0x95, 0x01,           //        Report Count (1)
-	0x91, 0x02,           //        Output (Data,Var,Abs)
-	0x95, 0x05,           //        Report Count (5)
+	0x91, 0x03,           //        Output (Data,Var,Abs)
+	0x95, 0x04,           //        Report Count (4)
 	0x91, 0x03,           //        Output (Constant, Variable)
 	0x09, 0x57,           //      Usage (Direction)
 	0xA1, 0x02,           //        Collection Datalink (Logical)
 	  0x0B, 0x01, 0, 0x0A, 0,  //          Usage (Ordinals: Instance 1)
 	  0x0B, 0x02, 0, 0x0A, 0,  //          Usage (Ordinals: Instance 2)
+	  0x0B, 0x03, 0, 0x0A, 0,  //          Usage (Ordinals: Instance 3)
 	  0x66, 0x14, 0x00,     //          Unit (20)
 	  0x55, 0xFE,           //          Unit Exponent (254)
 	  0x15, 0x00,           //          Logical Minimum (0)
@@ -138,11 +140,23 @@ static const uint8_t pidReportDescriptor[] PROGMEM= {
 	  0x47, 0xA0, 0x8C, 0, 0, //          Physical Maximum (36000)
 	  0x66, 0x00, 0x00,     //          Unit (0)
 	  0x75, 0x08,           //          Report Size (8)
-	  0x95, 0x02,           //          Report Count (2)
+	  0x95, 0x03,           //          Report Count (3)
 	  0x91, 0x02,           //          Output (Data,Var,Abs)
 	  0x55, 0x00,           //          Unit Exponent (0)
 	  0x66, 0x00, 0x00,     //          Unit (0)
 	0xC0,                 //        End Collection Datalink (Logical)
+
+	0x05, 0x0F,           //    Usage Page (Physical Interface)
+	0x09, 0x58,           //      Usage (Type Specific Block Offset)
+	0xA1, 0x02,           //        Collection (Logical)
+	 0x0B, 0x01, 0, 0x0A, 0,  //          Usage (Ordinals: Instance 1)
+	 0x0B, 0x02, 0, 0x0A, 0,  //          Usage (Ordinals: Instance 2)
+	 0x26, 0xFD, 0x7F,     //          Logical Maximum (32765); 32K RAM or ROM max.
+	 0x75, 0x10,           //          Report Size (16)
+	 0x95, 0x02,           //          Report Count (2)
+	 0x91, 0x02,           //          Output (Data,Var,Abs)
+	0xC0,                 //        End Collection (Logical)
+
   0xC0,                 //End Collection Datalink (Logical) (OK)
 
   // SetEnvelopeReport
@@ -370,12 +384,13 @@ static const uint8_t pidReportDescriptor[] PROGMEM= {
 	0x05, 0x01,           //  Usage Page (Generic Desktop)
 	0x09, 0x30,           //    Usage (X)
 	0x09, 0x31,           //    Usage (Y)
+	0x09, 0x32,           //    Usage (Z)
 	0x15, 0x81,           //     Logical Minimum (-127)
 	0x25, 0x7F,           //     Logical Maximum (127)
 	0x35, 0x00,           //     Physical Minimum (0)
 	0x46, 0xFF, 0x00,     //     Physical Maximum (255)
 	0x75, 0x08,           //     Report Size (8)
-	0x95, 0x02,           //     Report Count (2)
+	0x95, 0x03,           //     Report Count (3)
 	0x91, 0x02,           //     Output (Data,Var,Abs)
   0xC0,                 //End Collection Datalink (Logical) (OK)
 

--- a/src/FFBDescriptor.h
+++ b/src/FFBDescriptor.h
@@ -112,26 +112,34 @@ static const uint8_t pidReportDescriptor[] PROGMEM= {
 	0xA1, 0x02,           //      Collection Datalink (Logical)
 	  0x05, 0x01,           //        Usage Page (Generic Desktop)
 	  0x09, 0x30,           //        Usage (X)//
+      #if FFB_AXIS_COUNT >= 2
 	  0x09, 0x31,           //        Usage (Y)//
+      #endif
+      #if FFB_AXIS_COUNT >= 3
 	  0x09, 0x32,           //        Usage (Z)//
+      #endif
 	  0x15, 0x00,           //        Logical Minimum (0)
 	  0x25, 0x01,           //        Logical Maximum (1)
 	  0x75, 0x01,           //        Report Size (1)
-	  0x95, 0x03,           //        Report Count (3)
+	  0x95, FFB_AXIS_COUNT,           //        Report Count (3)
 	  0x91, 0x02,           //        Output (Data,Var,Abs)
 	0xC0,                 //      End Collection Datalink (Logical)
 
 	0x05, 0x0F,           //    Usage Page (Physical Interface)
 	0x09, 0x56,           //      Usage (Direction Enable)
 	0x95, 0x01,           //        Report Count (1)
-	0x91, 0x03,           //        Output (Data,Var,Abs)
-	0x95, 0x04,           //        Report Count (4)
+	0x91, 0x02,           //        Output (Data,Var,Abs)
+	0x95, 0x08 - FFB_AXIS_COUNT - 1,           //        Report Count (4)
 	0x91, 0x03,           //        Output (Constant, Variable)
 	0x09, 0x57,           //      Usage (Direction)
 	0xA1, 0x02,           //        Collection Datalink (Logical)
 	  0x0B, 0x01, 0, 0x0A, 0,  //          Usage (Ordinals: Instance 1)
+      #if FFB_AXIS_COUNT >= 2
 	  0x0B, 0x02, 0, 0x0A, 0,  //          Usage (Ordinals: Instance 2)
+      #endif
+      #if FFB_AXIS_COUNT >= 3
 	  0x0B, 0x03, 0, 0x0A, 0,  //          Usage (Ordinals: Instance 3)
+      #endif
 	  0x66, 0x14, 0x00,     //          Unit (20)
 	  0x55, 0xFE,           //          Unit Exponent (254)
 	  0x15, 0x00,           //          Logical Minimum (0)
@@ -140,7 +148,7 @@ static const uint8_t pidReportDescriptor[] PROGMEM= {
 	  0x47, 0xA0, 0x8C, 0, 0, //          Physical Maximum (36000)
 	  0x66, 0x00, 0x00,     //          Unit (0)
 	  0x75, 0x08,           //          Report Size (8)
-	  0x95, 0x03,           //          Report Count (3)
+	  0x95, FFB_AXIS_COUNT,           //          Report Count (3)
 	  0x91, 0x02,           //          Output (Data,Var,Abs)
 	  0x55, 0x00,           //          Unit Exponent (0)
 	  0x66, 0x00, 0x00,     //          Unit (0)
@@ -383,14 +391,18 @@ static const uint8_t pidReportDescriptor[] PROGMEM= {
 	0x85, 0x08,           //Report ID 8
 	0x05, 0x01,           //  Usage Page (Generic Desktop)
 	0x09, 0x30,           //    Usage (X)
+    #if FFB_AXIS_COUNT >= 2
 	0x09, 0x31,           //    Usage (Y)
+    #endif
+    #if FFB_AXIS_COUNT >= 3
 	0x09, 0x32,           //    Usage (Z)
+    #endif
 	0x15, 0x81,           //     Logical Minimum (-127)
 	0x25, 0x7F,           //     Logical Maximum (127)
 	0x35, 0x00,           //     Physical Minimum (0)
 	0x46, 0xFF, 0x00,     //     Physical Maximum (255)
 	0x75, 0x08,           //     Report Size (8)
-	0x95, 0x03,           //     Report Count (3)
+	0x95, FFB_AXIS_COUNT,           //     Report Count (3)
 	0x91, 0x02,           //     Output (Data,Var,Abs)
   0xC0,                 //End Collection Datalink (Logical) (OK)
 

--- a/src/Joystick.cpp
+++ b/src/Joystick.cpp
@@ -469,28 +469,26 @@ int32_t Joystick_::getEffectForce(volatile TEffectState& effect, EffectParams _e
     //    Serial.print("eA");
     //    Serial.print(effect.enableAxis);
     //    Serial.print("dX");
-    //    Serial.print(effect.directionX);
+    //    Serial.print(effect.direction[0]);
     //    Serial.print("dY");
-    //    Serial.println(effect.directionY);
+    //    Serial.println(effect.direction[1]);
     // }
 
-    uint8_t direction;
+    float angle_ratio;
     if (effect.enableAxis == DIRECTION_ENABLE)
     {
-        direction = effect.directionX;
+        float angle = (axis < 2 ? effect.direction[0] : effect.direction[1]) * 360.0 / 255.0 * DEG_TO_RAD;
+        if (axis == 0)
+        {
+            // angle=0 points "up"
+            angle_ratio = -1 * sin(angle);
+        } else {
+            angle_ratio = cos(angle);
+        }
     }
     else
     {
-        direction = axis == 0 ? effect.directionX : effect.directionY;
-    }
-
-    float angle;
-    angle = (direction * 360.0 / 255.0) * DEG_TO_RAD;
-    float angle_ratio;
-    if (axis == 0) {
-        angle_ratio = -1 * sin(angle);
-    } else {
-        angle_ratio = cos(angle);
+        angle_ratio = 1.0;
     }
 
 	int32_t force = 0;

--- a/src/Joystick.h
+++ b/src/Joystick.h
@@ -58,7 +58,6 @@
 #define DIRECTION_ENABLE                   0x04
 #define X_AXIS_ENABLE                      0x01
 #define Y_AXIS_ENABLE                      0x02
-#define FFB_AXIS_COUNT                     0x02
 #define FORCE_FEEDBACK_MAXGAIN              100
 #define DEG_TO_RAD              ((float)((float)3.14159265359 / 180.0))
 

--- a/src/Joystick.h
+++ b/src/Joystick.h
@@ -55,9 +55,6 @@
 #define JOYSTICK_TYPE_GAMEPAD              0x05
 #define JOYSTICK_TYPE_MULTI_AXIS           0x08
 
-#define DIRECTION_ENABLE                   0x04
-#define X_AXIS_ENABLE                      0x01
-#define Y_AXIS_ENABLE                      0x02
 #define FORCE_FEEDBACK_MAXGAIN              100
 #define DEG_TO_RAD              ((float)((float)3.14159265359 / 180.0))
 
@@ -148,8 +145,9 @@ private:
 	int32_t TriangleForceCalculator(volatile TEffectState& effect);
 	int32_t SawtoothDownForceCalculator(volatile TEffectState& effect);
 	int32_t SawtoothUpForceCalculator(volatile TEffectState& effect);
-	int32_t ConditionForceCalculator(volatile TEffectState& effect, float metric, uint8_t axis);
+	int32_t ConditionForceCalculator(volatile TEffectState& effect, float metric, uint8_t conditionReport);
 	void forceCalculator(int32_t* forces);
+	float getAngleRatio(volatile TEffectState& effect, int axis);
 	int32_t getEffectForce(volatile TEffectState& effect, EffectParams _effect_params, uint8_t axis);
 protected:
 	int buildAndSet16BitValue(bool includeValue, int16_t value, int16_t valueMinimum, int16_t valueMaximum, int16_t actualMinimum, int16_t actualMaximum, uint8_t dataLocation[]);


### PR DESCRIPTION
This PR is about making it possible to have condition effects receiving multiple reports (one per axis) or just one report based on the received directions.
In theory this should work by receiving the different axis enable flags but it doesn't seem to be supported properly. The workaround is having a variable that sets the number of condition reports received (it will be equal to the max offset condition report + 1)