### PR TITLE
add missing set rotation value functions

### DIFF
--- a/.projections.json
+++ b/.projections.json
@@ -1,6 +1,7 @@
 {
   "*": {
-    "make": "arduino-cli.exe compile --fqbn arduino:avr:micro --verbose brunnerdx",
-    "dispatch": "arduino-cli.exe upload --fqbn arduino:avr:micro --verbose brunnerdx -p $(arduino-cli.exe board list | grep Micro | cut -d' ' -f1)",
+    "make": "arduino-cli.exe compile --fqbn arduino:avr:micro --verbose",
+    "dispatch": "arduino-cli.exe upload --fqbn arduino:avr:micro --verbose Fino -p $(arduino-cli.exe board list | grep Micro | cut -d' ' -f1)",
+
   }
 }

--- a/src/Joystick.cpp
+++ b/src/Joystick.cpp
@@ -882,6 +882,26 @@ void Joystick_::setZAxis(int16_t value)
 	if (_autoSendState) sendState();
 }
 
+void Joystick_::setRxAxis(int16_t value)
+{
+	_xAxisRotation = value;
+	if (_autoSendState) sendState();
+}
+
+
+void Joystick_::setRyAxis(int16_t value)
+{
+	_yAxisRotation = value;
+	if (_autoSendState) sendState();
+}
+
+
+void Joystick_::setRzAxis(int16_t value)
+{
+	_zAxisRotation = value;
+	if (_autoSendState) sendState();
+}
+
 void Joystick_::setRudder(int16_t value)
 {
 	_rudder = value;


### PR DESCRIPTION
fix #31 
The Joystick.cpp file lacks the implementation of functions: setRxAxis(), setRyAxis(), setRzAxis()