### PR TITLE
Dial and slider axes

### DIFF
--- a/Fino.ino
+++ b/Fino.ino
@@ -46,7 +46,7 @@ Joystick_ Joystick(
     19, 2, // Button Count, Hat Switch Count
     true, true, false, // X, Y, Z
     false, false, false, // Rx, Ry, Rz
-    true, true); // rudder, throttle
+    true, true); // dial, throttle
 
 void setup() {
 

--- a/Fino.ino
+++ b/Fino.ino
@@ -46,7 +46,7 @@ Joystick_ Joystick(
     19, 2, // Button Count, Hat Switch Count
     true, true, false, // X, Y, Z
     false, false, false, // Rx, Ry, Rz
-    true, true); // dial, throttle
+    true, true); // slider, dial
 
 void setup() {
 

--- a/src/Joystick.cpp
+++ b/src/Joystick.cpp
@@ -40,7 +40,7 @@
 #define JOYSTICK_INCLUDE_RY_AXIS B00010000
 #define JOYSTICK_INCLUDE_RZ_AXIS B00100000
 
-#define JOYSTICK_INCLUDE_RUDDER      B00000001
+#define JOYSTICK_INCLUDE_DIAL      B00000001
 #define JOYSTICK_INCLUDE_THROTTLE    B00000010
 #define JOYSTICK_INCLUDE_ACCELERATOR B00000100
 
@@ -66,7 +66,7 @@ Joystick_::Joystick_(
 	bool includeRxAxis,
 	bool includeRyAxis,
 	bool includeRzAxis,
-	bool includeRudder,
+	bool includeDial,
 	bool includeThrottle)
 {
     // Set the USB HID Report ID
@@ -83,7 +83,7 @@ Joystick_::Joystick_(
 	_includeAxisFlags |= (includeRyAxis ? JOYSTICK_INCLUDE_RY_AXIS : 0);
 	_includeAxisFlags |= (includeRzAxis ? JOYSTICK_INCLUDE_RZ_AXIS : 0);
 	_includeSimulatorFlags = 0;
-	_includeSimulatorFlags |= (includeRudder ? JOYSTICK_INCLUDE_RUDDER : 0);
+	_includeSimulatorFlags |= (includeDial ? JOYSTICK_INCLUDE_DIAL : 0);
 	_includeSimulatorFlags |= (includeThrottle ? JOYSTICK_INCLUDE_THROTTLE : 0);
 	
     // Build Joystick HID Report Description
@@ -104,7 +104,7 @@ Joystick_::Joystick_(
 		+  (includeRyAxis == true)
 		+  (includeRzAxis == true);
 		
-	uint8_t simulationCount = (includeRudder == true)
+	uint8_t simulationCount = (includeDial == true)
 		+ (includeThrottle == true); 
 		
 	static uint8_t tempHidReportDescriptor[150];
@@ -394,8 +394,8 @@ Joystick_::Joystick_(
 		tempHidReportDescriptor[hidReportDescriptorSize++] = 0xA1;
 		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x00;
 
-		if (includeRudder == true) {
-			// USAGE (Rudder)
+		if (includeDial == true) {
+			// USAGE (Dial)
 			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x09;
 			tempHidReportDescriptor[hidReportDescriptorSize++] = 0xBA;
 		}
@@ -445,7 +445,7 @@ Joystick_::Joystick_(
 	_yAxisRotation = 0;
 	_zAxisRotation = 0;
 	_throttle = 0;
-	_rudder = 0;
+	_dial = 0;
 	for (int index = 0; index < JOYSTICK_HATSWITCH_COUNT_MAXIMUM; index++)
 	{
 		_hatSwitchValues[index] = JOYSTICK_HATSWITCH_RELEASE;
@@ -902,9 +902,9 @@ void Joystick_::setRzAxis(int16_t value)
 	if (_autoSendState) sendState();
 }
 
-void Joystick_::setRudder(int16_t value)
+void Joystick_::setDial(int16_t value)
 {
-	_rudder = value;
+	_dial = value;
 	if (_autoSendState) sendState();
 }
 void Joystick_::setThrottle(int16_t value)
@@ -1006,7 +1006,7 @@ void Joystick_::sendState()
 	index += buildAndSetAxisValue(_includeAxisFlags & JOYSTICK_INCLUDE_RZ_AXIS, _zAxisRotation, _rzAxisMinimum, _rzAxisMaximum, &(data[index]));
 	
 	// Set Simulation Values
-	index += buildAndSetSimulationValue(_includeSimulatorFlags & JOYSTICK_INCLUDE_RUDDER, _rudder, _rudderMinimum, _rudderMaximum, &(data[index]));
+	index += buildAndSetSimulationValue(_includeSimulatorFlags & JOYSTICK_INCLUDE_DIAL, _dial, _dial, _dial, &(data[index]));
 	index += buildAndSetSimulationValue(_includeSimulatorFlags & JOYSTICK_INCLUDE_THROTTLE, _throttle, _throttleMinimum, _throttleMaximum, &(data[index]));
 
 	DynamicHID().SendReport(_hidReportId, data, _hidReportSize);

--- a/src/Joystick.cpp
+++ b/src/Joystick.cpp
@@ -39,10 +39,8 @@
 #define JOYSTICK_INCLUDE_RX_AXIS B00001000
 #define JOYSTICK_INCLUDE_RY_AXIS B00010000
 #define JOYSTICK_INCLUDE_RZ_AXIS B00100000
-
-#define JOYSTICK_INCLUDE_DIAL      B00000001
-#define JOYSTICK_INCLUDE_THROTTLE    B00000010
-#define JOYSTICK_INCLUDE_ACCELERATOR B00000100
+#define JOYSTICK_INCLUDE_SLIDER  B01000000
+#define JOYSTICK_INCLUDE_DIAL    B10000000
 
 const float cutoff_freq_damper   = 2.0;  //Cutoff frequency in Hz
 const float sampling_time_damper = 0.002; //Sampling time in seconds.
@@ -66,8 +64,8 @@ Joystick_::Joystick_(
 	bool includeRxAxis,
 	bool includeRyAxis,
 	bool includeRzAxis,
-	bool includeDial,
-	bool includeThrottle)
+	bool includeSlider,
+	bool includeDial)
 {
     // Set the USB HID Report ID
     _hidReportId = hidReportId;
@@ -82,9 +80,9 @@ Joystick_::Joystick_(
 	_includeAxisFlags |= (includeRxAxis ? JOYSTICK_INCLUDE_RX_AXIS : 0);
 	_includeAxisFlags |= (includeRyAxis ? JOYSTICK_INCLUDE_RY_AXIS : 0);
 	_includeAxisFlags |= (includeRzAxis ? JOYSTICK_INCLUDE_RZ_AXIS : 0);
-	_includeSimulatorFlags = 0;
-	_includeSimulatorFlags |= (includeDial ? JOYSTICK_INCLUDE_DIAL : 0);
-	_includeSimulatorFlags |= (includeThrottle ? JOYSTICK_INCLUDE_THROTTLE : 0);
+	_includeAxisFlags |= (includeSlider ? JOYSTICK_INCLUDE_SLIDER : 0);
+	_includeAxisFlags |= (includeDial ? JOYSTICK_INCLUDE_DIAL : 0);
+
 	
     // Build Joystick HID Report Description
 	
@@ -102,10 +100,9 @@ Joystick_::Joystick_(
 		+  (includeZAxis == true)
 		+  (includeRxAxis == true)
 		+  (includeRyAxis == true)
-		+  (includeRzAxis == true);
-		
-	uint8_t simulationCount = (includeDial == true)
-		+ (includeThrottle == true); 
+		+  (includeRzAxis == true)
+		+  (includeSlider == true)
+		+  (includeDial == true);
 		
 	static uint8_t tempHidReportDescriptor[150];
 	int hidReportDescriptorSize = 0;
@@ -357,6 +354,18 @@ Joystick_::Joystick_(
 			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x35;
 		}
 		
+		if (includeSlider == true) {
+			// USAGE (Rz)
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x09;
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x36;
+		}		
+	
+		if (includeDial == true) {
+			// USAGE (Rz)
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x09;
+			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x37;
+		}
+		
 		// INPUT (Data,Var,Abs)
 		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x81;
 		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x02;
@@ -365,54 +374,6 @@ Joystick_::Joystick_(
 		tempHidReportDescriptor[hidReportDescriptorSize++] = 0xc0;
 		
 	} // X, Y, Z, Rx, Ry, and Rz Axis	
-	
-	if (simulationCount > 0) {
-	
-		// USAGE_PAGE (Simulation Controls)
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x05;
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x02;
-		
-		// LOGICAL_MINIMUM (-32767)
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x16;
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x01;
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x80;
-
-		// LOGICAL_MAXIMUM (+32767)
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x26;
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0xFF;
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x7F;
-
-		// REPORT_SIZE (16)
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x75;
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x10;
-
-		// REPORT_COUNT (simulationCount)
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x95;
-		tempHidReportDescriptor[hidReportDescriptorSize++] = simulationCount;
-
-		// COLLECTION (Physical)
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0xA1;
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x00;
-
-		if (includeDial == true) {
-			// USAGE (Dial)
-			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x09;
-			tempHidReportDescriptor[hidReportDescriptorSize++] = 0xBA;
-		}
-
-		if (includeThrottle == true) {
-			// USAGE (Throttle)
-			tempHidReportDescriptor[hidReportDescriptorSize++] = 0x09;
-			tempHidReportDescriptor[hidReportDescriptorSize++] = 0xBB;
-		}
-
-		// INPUT (Data,Var,Abs)
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x81;
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0x02;
-		
-		// END_COLLECTION (Physical) 
-		tempHidReportDescriptor[hidReportDescriptorSize++] = 0xc0;
-	} // Simulation Controls
 
 	// Create a copy of the HID Report Descriptor template that is just the right size
 	uint8_t *customHidReportDescriptor = new uint8_t[hidReportDescriptorSize];
@@ -435,7 +396,6 @@ Joystick_::Joystick_(
 	_hidReportSize = _buttonValuesArraySize;
 	_hidReportSize += (_hatSwitchCount > 0);
 	_hidReportSize += (axisCount * 2);
-	_hidReportSize += (simulationCount * 2);
 	
 	// Initalize Joystick State
 	_xAxis = 0;
@@ -444,8 +404,9 @@ Joystick_::Joystick_(
 	_xAxisRotation = 0;
 	_yAxisRotation = 0;
 	_zAxisRotation = 0;
-	_throttle = 0;
+	_slider = 0;
 	_dial = 0;
+	
 	for (int index = 0; index < JOYSTICK_HATSWITCH_COUNT_MAXIMUM; index++)
 	{
 		_hatSwitchValues[index] = JOYSTICK_HATSWITCH_RELEASE;
@@ -901,15 +862,14 @@ void Joystick_::setRzAxis(int16_t value)
 	_zAxisRotation = value;
 	if (_autoSendState) sendState();
 }
-
+void Joystick_::setSlider(int16_t value)
+{
+	_slider = value;
+	if (_autoSendState) sendState();
+}
 void Joystick_::setDial(int16_t value)
 {
 	_dial = value;
-	if (_autoSendState) sendState();
-}
-void Joystick_::setThrottle(int16_t value)
-{
-	_throttle = value;
 	if (_autoSendState) sendState();
 }
 
@@ -1004,11 +964,9 @@ void Joystick_::sendState()
 	index += buildAndSetAxisValue(_includeAxisFlags & JOYSTICK_INCLUDE_RX_AXIS, _xAxisRotation, _rxAxisMinimum, _rxAxisMaximum, &(data[index]));
 	index += buildAndSetAxisValue(_includeAxisFlags & JOYSTICK_INCLUDE_RY_AXIS, _yAxisRotation, _ryAxisMinimum, _ryAxisMaximum, &(data[index]));
 	index += buildAndSetAxisValue(_includeAxisFlags & JOYSTICK_INCLUDE_RZ_AXIS, _zAxisRotation, _rzAxisMinimum, _rzAxisMaximum, &(data[index]));
+	index += buildAndSetAxisValue(_includeAxisFlags & JOYSTICK_INCLUDE_SLIDER, _slider, _sliderMinimum, _sliderMaximum, &(data[index]));
+	index += buildAndSetAxisValue(_includeAxisFlags & JOYSTICK_INCLUDE_DIAL, _dial, _dialMinimum, _dialMaximum, &(data[index]));
 	
-	// Set Simulation Values
-	index += buildAndSetSimulationValue(_includeSimulatorFlags & JOYSTICK_INCLUDE_DIAL, _dial, _dial, _dial, &(data[index]));
-	index += buildAndSetSimulationValue(_includeSimulatorFlags & JOYSTICK_INCLUDE_THROTTLE, _throttle, _throttleMinimum, _throttleMaximum, &(data[index]));
-
 	DynamicHID().SendReport(_hidReportId, data, _hidReportSize);
 }
 

--- a/src/Joystick.h
+++ b/src/Joystick.h
@@ -100,7 +100,7 @@ private:
 	int16_t	                 _xAxisRotation;
 	int16_t	                 _yAxisRotation;
 	int16_t	                 _zAxisRotation;
-	int16_t                  _throttle;
+	int16_t                  _slider;
 	int16_t                  _dial;
 	int16_t	                 _hatSwitchValues[JOYSTICK_HATSWITCH_COUNT_MAXIMUM];
     uint8_t                 *_buttonValues = NULL;
@@ -124,10 +124,11 @@ private:
 	int16_t                  _ryAxisMaximum = JOYSTICK_DEFAULT_AXIS_MAXIMUM;
 	int16_t                  _rzAxisMinimum = JOYSTICK_DEFAULT_AXIS_MINIMUM;
 	int16_t                  _rzAxisMaximum = JOYSTICK_DEFAULT_AXIS_MAXIMUM;
-	int16_t                  _dialMinimum = JOYSTICK_DEFAULT_SIMULATOR_MINIMUM;
-	int16_t                  _dialMaximum = JOYSTICK_DEFAULT_SIMULATOR_MAXIMUM;
-	int16_t                  _throttleMinimum = JOYSTICK_DEFAULT_SIMULATOR_MINIMUM;
-	int16_t                  _throttleMaximum = JOYSTICK_DEFAULT_SIMULATOR_MAXIMUM;
+	int16_t                  _sliderMinimum = JOYSTICK_DEFAULT_AXIS_MINIMUM;
+	int16_t                  _sliderMaximum = JOYSTICK_DEFAULT_AXIS_MAXIMUM;
+	int16_t                  _dialMinimum = JOYSTICK_DEFAULT_AXIS_MINIMUM;
+	int16_t                  _dialMaximum = JOYSTICK_DEFAULT_AXIS_MAXIMUM;
+
 
 	uint8_t                  _hidReportId;
 	uint8_t                  _hidReportSize; 
@@ -170,8 +171,8 @@ public:
 		bool includeRxAxis = true,
 		bool includeRyAxis = true,
 		bool includeRzAxis = true,
-		bool includeDial = true,
-		bool includeThrottle = true);
+		bool includeSlider = false,
+		bool includeDial = false);
 
 	void begin(bool initAutoSendState = true);
 	void end();
@@ -206,16 +207,17 @@ public:
 		_rzAxisMinimum = minimum;
 		_rzAxisMaximum = maximum;
 	}
+	inline void setSliderRange(int16_t minimum, int16_t maximum)
+	{
+		_sliderMinimum = minimum;
+		_sliderMaximum = maximum;
+	}	
 	inline void setDialRange(int16_t minimum, int16_t maximum)
 	{
 		_dialMinimum = minimum;
 		_dialMaximum = maximum;
 	}
-	inline void setThrottleRange(int16_t minimum, int16_t maximum)
-	{
-		_throttleMinimum = minimum;
-		_throttleMaximum = maximum;
-	}
+	
 
 	// Set Axis Values
 	void setXAxis(int16_t value);
@@ -224,10 +226,8 @@ public:
 	void setRxAxis(int16_t value);
 	void setRyAxis(int16_t value);
 	void setRzAxis(int16_t value);
-
-	// Set Simuation Values
+	void setSlider(int16_t value);
 	void setDial(int16_t value);
-	void setThrottle(int16_t value);
 
 	void setButton(uint8_t button, uint8_t value);
 	void pressButton(uint8_t button);

--- a/src/Joystick.h
+++ b/src/Joystick.h
@@ -101,7 +101,7 @@ private:
 	int16_t	                 _yAxisRotation;
 	int16_t	                 _zAxisRotation;
 	int16_t                  _throttle;
-	int16_t                  _rudder;
+	int16_t                  _dial;
 	int16_t	                 _hatSwitchValues[JOYSTICK_HATSWITCH_COUNT_MAXIMUM];
     uint8_t                 *_buttonValues = NULL;
 
@@ -124,8 +124,8 @@ private:
 	int16_t                  _ryAxisMaximum = JOYSTICK_DEFAULT_AXIS_MAXIMUM;
 	int16_t                  _rzAxisMinimum = JOYSTICK_DEFAULT_AXIS_MINIMUM;
 	int16_t                  _rzAxisMaximum = JOYSTICK_DEFAULT_AXIS_MAXIMUM;
-	int16_t                  _rudderMinimum = JOYSTICK_DEFAULT_SIMULATOR_MINIMUM;
-	int16_t                  _rudderMaximum = JOYSTICK_DEFAULT_SIMULATOR_MAXIMUM;
+	int16_t                  _dialMinimum = JOYSTICK_DEFAULT_SIMULATOR_MINIMUM;
+	int16_t                  _dialMaximum = JOYSTICK_DEFAULT_SIMULATOR_MAXIMUM;
 	int16_t                  _throttleMinimum = JOYSTICK_DEFAULT_SIMULATOR_MINIMUM;
 	int16_t                  _throttleMaximum = JOYSTICK_DEFAULT_SIMULATOR_MAXIMUM;
 
@@ -170,7 +170,7 @@ public:
 		bool includeRxAxis = true,
 		bool includeRyAxis = true,
 		bool includeRzAxis = true,
-		bool includeRudder = true,
+		bool includeDial = true,
 		bool includeThrottle = true);
 
 	void begin(bool initAutoSendState = true);
@@ -206,10 +206,10 @@ public:
 		_rzAxisMinimum = minimum;
 		_rzAxisMaximum = maximum;
 	}
-	inline void setRudderRange(int16_t minimum, int16_t maximum)
+	inline void setDialRange(int16_t minimum, int16_t maximum)
 	{
-		_rudderMinimum = minimum;
-		_rudderMaximum = maximum;
+		_dialMinimum = minimum;
+		_dialMaximum = maximum;
 	}
 	inline void setThrottleRange(int16_t minimum, int16_t maximum)
 	{
@@ -226,7 +226,7 @@ public:
 	void setRzAxis(int16_t value);
 
 	// Set Simuation Values
-	void setRudder(int16_t value);
+	void setDial(int16_t value);
 	void setThrottle(int16_t value);
 
 	void setButton(uint8_t button, uint8_t value);


### PR DESCRIPTION
This is about removing the rudder and thottle axes and changing those for dial and slider.
Rudder and throttle were working correctly, but dial and slider seem better supported in Windows and this change would not impact anyone negatively as far as I can see